### PR TITLE
[REF] wlc: Support unconfigured host from list_factory

### DIFF
--- a/wlc/__init__.py
+++ b/wlc/__init__.py
@@ -108,13 +108,17 @@ class Weblate(object):
 
     def list_factory(self, path, parser):
         """Wrapper for listing objects."""
+        original_path = path
         while path is not None:
             data = self.get(path)
 
             for item in data['results']:
                 yield parser(weblate=self, **item)
 
-            path = data['next']
+            url_next = data['next']
+            if url_next and not original_path.startswith('http'):
+                url_next = '{0}{1}'.format(original_path, url_next.split('/')[-1])
+            path = url_next
 
     def _get_factory(self, prefix, path, parser):
         """Wrapper for getting objects."""


### PR DESCRIPTION
If you don't have configured a host from server side you will see a error for list-components for page >= 2

Example, using the following configuration `~/.weblate` file.
```config
[weblate]
url=https://weblate.vauxoo.com/api/
key=********
```

Run the command: `wlc list-components`
You will see a not found error.

This is because we are using the returned `request['next']` value and this one is bad configured.
<img width="1072" alt="screen shot 2016-12-03 at 8 59 38 pm" src="https://cloud.githubusercontent.com/assets/6644187/20863748/17fbdd5e-b99b-11e6-850e-6144a28fe53e.png">

Maybe we could manage this part from client side with this patch