### PR TITLE
Add replace choice in upload command

### DIFF
--- a/wlc/main.py
+++ b/wlc/main.py
@@ -626,7 +626,7 @@ class Upload(TranslationCommand):
         )
         parser.add_argument(
             "--method",
-            choices=("translate", "approve", "suggest", "fuzzy"),
+            choices=("translate", "approve", "suggest", "fuzzy", "replace"),
             default="translate",
         )
         parser.add_argument("--fuzzy", choices=("", "process", "approve"), default="")


### PR DESCRIPTION
According to weblate web api there is an extra choice for replace the entire file, that the wlc cli do not support currently.

https://docs.weblate.org/en/latest/api.html#post--api-translations-(string-project)-(string-component)-(string-language)-file-