### PR TITLE
Fix isort configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,13 @@ on:
   push:
     paths:
       - '**.py'
+      - 'setup.cfg'
+      - 'requirements*.txt'
   pull_request:
     paths:
       - '**.py'
+      - 'setup.cfg'
+      - 'requirements*.txt'
 
 jobs:
   flake8:

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,4 @@ force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
 project = wlc
-known_third_party = xdg
+known_third_party = xdg,httpretty,requests,dateutil


### PR DESCRIPTION
Correctly mark third party modules to make it work even without these
being installed.

Signed-off-by: Michal Čihař <michal@cihar.com>