### PR TITLE
support bash completion using argcomplete

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.rst
 include LICENSE
 include CHANGES.rst
 include MANIFEST.in
+include completion/wlc
 include requirements.txt
 include requirements-test.txt
 include wlc/*.py

--- a/completion/wlc
+++ b/completion/wlc
@@ -1,0 +1,22 @@
+
+_python_argcomplete() {
+    local IFS=$'\013'
+    local SUPPRESS_SPACE=0
+    if compopt +o nospace 2> /dev/null; then
+        SUPPRESS_SPACE=1
+    fi
+    COMPREPLY=( $(IFS="$IFS" \
+                  COMP_LINE="$COMP_LINE" \
+                  COMP_POINT="$COMP_POINT" \
+                  COMP_TYPE="$COMP_TYPE" \
+                  _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
+                  _ARGCOMPLETE=1 \
+                  _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
+                  "$1" 8>&1 9>&2 1>/dev/null 2>/dev/null) )
+    if [[ $? != 0 ]]; then
+        unset COMPREPLY
+    elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "$COMPREPLY" =~ [=/:]$ ]]; then
+        compopt -o nospace
+    fi
+}
+complete -o nospace -o default -F _python_argcomplete "wlc"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 HTTPretty!=0.8.11,!=0.8.12,!=0.8.13,!=0.8.14
+argcomplete
 multipart
 pre-commit
 pytest

--- a/wlc/main.py
+++ b/wlc/main.py
@@ -1,3 +1,4 @@
+# PYTHON_ARGCOMPLETE_OK
 #
 # Copyright © 2012 - 2020 Michal Čihař <michal@cihar.com>
 #
@@ -73,6 +74,13 @@ def get_parser():
 
     for command in COMMANDS.values():
         command.add_parser(subparser)
+
+    try:
+        import argcomplete
+
+        argcomplete.autocomplete(parser)
+    except ImportError:
+        pass
 
     return parser
 


### PR DESCRIPTION
Using the Python library [argcomplete](https://github.com/kislyuk/argcomplete) this makes automatic bash completion based on `argparse`.  It is option, so it will silently ignore the code if _argcomplete_ is not locally installed.