### PR TITLE
entry_points added to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,10 @@ packages = wlc
 python_requires = >=3.6
 package_dir = wlc=wlc
 
+[options.entry_points]
+console_scripts =
+    wlc = wlc.main:main
+
 [flake8]
 max-complexity = 16
 select = E,W1,W2,W3,W504,W505,W6


### PR DESCRIPTION
No console scripts are being generated on package install after recent release.
Looks like your setup.cfg is missing few lines in "entry_points" section. I've added them.