### PR TITLE
Use "raise from"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,6 @@ ignore = [
   "D401",  # TODO: many strings need rephrasing
   "T201",  # WONTFIX: using print() (maybe add noqa)
   "TRY003",  # WONTFIX: Avoid specifying long messages outside the exception class
-  "TRY200",  # TODO: Use `raise from` to specify exception cause
-  "B904",  # TODO: Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
   "PLR0913",  # WONTFIX: Too many arguments to function call
   "PLR2004",  # TODO: Magic value used in comparison, consider replacing 201 with a constant variable
   "N818"  # TODO: exception naming


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

For wlc exceptions indicate that an exception is a direct consequence of another (see [exception chaining](https://docs.python.org/3/tutorial/errors.html#exception-chaining)).

In practice it changes a following example traceback:
```Traceback (most recent call last):
  File "projects/wlc/wlc/__init__.py", line 201, in invoke_request
    response.raise_for_status()
  File ".pyenv/versions/wlc/lib/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 429 Client Error: Too Many Requests for url: https://hosted.weblate.org/api/projects/python-docs/

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "projects/python-docs-weblate/.update-translation.py", line 69, in <module>
    _update_translation(options.language, weblate_key=weblate_key)
  …
  File "projects/wlc/wlc/__init__.py", line 128, in process_error
    raise WeblateThrottlingError
wlc.WeblateThrottlingError: Throttling on the server.
```
into:
```
Traceback (most recent call last):
  File "projects/wlc/wlc/__init__.py", line 201, in invoke_request
    response.raise_for_status()
  File ".pyenv/versions/wlc/lib/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 429 Client Error: Too Many Requests for url: https://hosted.weblate.org/api/projects/python-docs/

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "projects/python-docs-weblate/.update-translation.py", line 69, in <module>
    _update_translation(options.language, weblate_key=weblate_key)
  …
  File "projects/wlc/wlc/__init__.py", line 128, in process_error
    raise WeblateThrottlingError from error
wlc.WeblateThrottlingError: Throttling on the server.
```
(Note the linking phrase between the tracebacks.)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- ~~I have added documentation to describe my feature.~~
- ~~I have squashed my commits into logic units.~~
- [x] I have described the changes in the commit messages.
