### PR TITLE
Fix project.languages() method

### DIFF
--- a/wlc/__init__.py
+++ b/wlc/__init__.py
@@ -582,7 +582,7 @@ class Project(LazyObject, RepoObjectMixin):
         self.ensure_loaded("languages_url")
         url = self._attribs["languages_url"]
         return [
-            LanguageStats(self.weblate, url, **item) for item in self.weblate.get(url)
+            LanguageStats(self.weblate, **item) for item in self.weblate.get(url)
         ]
 
     def changes(self):

--- a/wlc/__init__.py
+++ b/wlc/__init__.py
@@ -581,9 +581,7 @@ class Project(LazyObject, RepoObjectMixin):
         """Return language statistics for component."""
         self.ensure_loaded("languages_url")
         url = self._attribs["languages_url"]
-        return [
-            LanguageStats(self.weblate, **item) for item in self.weblate.get(url)
-        ]
+        return [LanguageStats(self.weblate, **item) for item in self.weblate.get(url)]
 
     def changes(self):
         """List changes in the project."""

--- a/wlc/test_data/api/projects-hello-languages
+++ b/wlc/test_data/api/projects-hello-languages
@@ -7,7 +7,7 @@
         "translated": 5,
         "translated_percent": 62.5,
         "total": 8,
-        "url": "http://127.0.0.1:8000/api/projects/hello/languages/cs/",
+        "url": "http://127.0.0.1:8000/projects/hello/-/cs/",
         "words_percent": 63.3
     },
     {
@@ -18,7 +18,7 @@
         "translated": 4,
         "translated_percent": 50.0,
         "total": 8,
-        "url": "http://127.0.0.1:8000/api/projects/hello/languages/en/",
+        "url": "http://127.0.0.1:8000/projects/hello/-/en/",
         "words_percent": 50.0
     }
   ]

--- a/wlc/test_data/api/projects-hello-languages
+++ b/wlc/test_data/api/projects-hello-languages
@@ -7,6 +7,7 @@
         "translated": 5,
         "translated_percent": 62.5,
         "total": 8,
+        "url": "http://127.0.0.1:8000/api/projects/hello/languages/cs/",
         "words_percent": 63.3
     },
     {
@@ -17,6 +18,7 @@
         "translated": 4,
         "translated_percent": 50.0,
         "total": 8,
+        "url": "http://127.0.0.1:8000/api/projects/hello/languages/en/",
         "words_percent": 50.0
     }
   ]


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
Fix project.languages() method.

LanguageStats constructing was doubling `url` argument.

The url attribute seems to be part of REST API responses for long (at least since 3.8 https://github.com/WeblateOrg/weblate/commit/3a3b387b0ab4eae8e58fd3f3c06342b80b1d7a7a)

Code currently failing:

```
Traceback (most recent call last):
  File "site-packages/wlc/__init__.py", line 564, in languages
    return [
           ^
  File "site-packages/wlc/__init__.py", line 565, in <listcomp>
    LanguageStats(self.weblate, url, **item) for item in self.weblate.get(url)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: LazyObject.__init__() got multiple values for argument 'url'
```

[GitHub Actions example.](https://github.com/m-aciek/python-docs-pl-weblate-poc/actions/runs/6304882707/job/17117177536)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- ~~[ ] I have added documentation to describe my feature.~~
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
