### PR TITLE
upload: Add --conflicts support

### DIFF
--- a/wlc/main.py
+++ b/wlc/main.py
@@ -725,11 +725,7 @@ class Upload(TranslationCommand):
         )
         parser.add_argument(
             "--conflicts",
-            choices=(
-                "ignore",
-                "replace-translated",
-                "replace-approved"
-            ),
+            choices=("ignore", "replace-translated", "replace-approved"),
         )
         parser.add_argument(
             "--author-name",


### PR DESCRIPTION
The `conflicts` key is currently missing from the `wlc` command line tool, but is present in the [API docs][1]

[1]: https://docs.weblate.org/en/latest/api.html#post--api-translations-(string-project)-(string-component)-(string-language)-file-
