### PR TITLE
fix: avoid using startswith for SSL configuration

### DIFF
--- a/wlc/__init__.py
+++ b/wlc/__init__.py
@@ -28,7 +28,8 @@ URL = "https://weblate.org/"
 DEVEL_URL = "https://github.com/WeblateOrg/wlc"
 API_URL = "http://127.0.0.1:8000/api/"
 USER_AGENT = f"wlc/{__version__}"
-LOCALHOST_NETLOC = "127.0.0.1"
+LOCALHOST_ADDRESSES = {"127.0.0.1", "localhost", "::1", "[::1]"}
+
 TIMESTAMPS = {"last_change"}
 
 
@@ -195,7 +196,7 @@ class Weblate:
         headers = {"user-agent": USER_AGENT, "Accept": "application/json"}
         if self.key:
             headers["Authorization"] = f"Token {self.key}"
-        verify_ssl = self._should_verify_ssl(path)
+        verify_ssl = self.should_verify_ssl(path)
         kwargs = {
             "headers": headers,
             "verify": verify_ssl,
@@ -374,11 +375,10 @@ class Weblate:
         return self.post("languages/", **data)
 
     @staticmethod
-    def _should_verify_ssl(path):
+    def should_verify_ssl(path: str) -> bool:
         """Checks if it should verify ssl certificates."""
         url = urlparse(path)
-        is_localhost = url.netloc.startswith(LOCALHOST_NETLOC)
-        return url.scheme == "https" and (not is_localhost)
+        return url.hostname not in LOCALHOST_ADDRESSES
 
 
 class LazyObject(dict):

--- a/wlc/test_wlc.py
+++ b/wlc/test_wlc.py
@@ -300,6 +300,14 @@ class WeblateTest(APITest):
                     filemask="po/*.po",
                 )
 
+    def test_should_verify_ssl(self) -> None:
+        self.assertEqual(Weblate.should_verify_ssl("http://localhost/api/"), False)
+        self.assertEqual(Weblate.should_verify_ssl("invalid/api/"), True)
+        self.assertEqual(
+            Weblate.should_verify_ssl("https://localhost.example.com/api/"), True
+        )
+        self.assertEqual(Weblate.should_verify_ssl("http://example.com/api/"), True)
+
 
 class ObjectTestBaseClass(APITest):
     """Base class for objects testing."""


### PR DESCRIPTION
It would wrongly match hosts whose domain name starts with 127.0.0.1.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
