### PR TITLE
fix(main): add `__eq__` for LazyObject

### DIFF
--- a/wlc/__init__.py
+++ b/wlc/__init__.py
@@ -429,6 +429,20 @@ class LazyObject(dict):
     def __init__(self, weblate, url, **kwargs) -> None:
         """Construct object for given Weblate instance."""
         super().__init__()
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, LazyObject):
+            return (
+                dict(self) == dict(other)
+                and self.weblate == other.weblate
+                and self._url == other._url
+                and self._data == other._data
+                and self._loaded == other._loaded
+                and self._attribs == other._attribs
+            )
+        if isinstance(other, dict):
+            return dict(self) == other
+        return NotImplemented
+
         self.weblate = weblate
         self._url = url
         self._data: dict[str, Any] = {}

--- a/wlc/__init__.py
+++ b/wlc/__init__.py
@@ -429,6 +429,7 @@ class LazyObject(dict):
     def __init__(self, weblate, url, **kwargs) -> None:
         """Construct object for given Weblate instance."""
         super().__init__()
+
     def __eq__(self, other: object) -> bool:
         if isinstance(other, LazyObject):
             return (

--- a/wlc/__init__.py
+++ b/wlc/__init__.py
@@ -430,6 +430,14 @@ class LazyObject(dict):
         """Construct object for given Weblate instance."""
         super().__init__()
 
+        self.weblate = weblate
+        self._url = url
+        self._data: dict[str, Any] = {}
+        self._loaded = False
+        self._attribs: dict[str, Any] = {}
+        self._load_params(**kwargs)
+        self._load_params(url=url)
+        
     def __eq__(self, other: object) -> bool:
         if isinstance(other, LazyObject):
             return (
@@ -443,15 +451,7 @@ class LazyObject(dict):
         if isinstance(other, dict):
             return dict(self) == other
         return NotImplemented
-
-        self.weblate = weblate
-        self._url = url
-        self._data: dict[str, Any] = {}
-        self._loaded = False
-        self._attribs: dict[str, Any] = {}
-        self._load_params(**kwargs)
-        self._load_params(url=url)
-
+    
     def get_data(self):
         return copy(self._data)
 

--- a/wlc/__init__.py
+++ b/wlc/__init__.py
@@ -437,7 +437,7 @@ class LazyObject(dict):
         self._attribs: dict[str, Any] = {}
         self._load_params(**kwargs)
         self._load_params(url=url)
-        
+
     def __eq__(self, other: object) -> bool:
         if isinstance(other, LazyObject):
             return (
@@ -451,7 +451,7 @@ class LazyObject(dict):
         if isinstance(other, dict):
             return dict(self) == other
         return NotImplemented
-    
+
     def get_data(self):
         return copy(self._data)
 

--- a/wlc/__init__.py
+++ b/wlc/__init__.py
@@ -441,15 +441,14 @@ class LazyObject(dict):
     def __eq__(self, other: object) -> bool:
         if isinstance(other, LazyObject):
             return (
-                self.as_dict() == other.as_dict()
-                and self.weblate == other.weblate
+                self.weblate == other.weblate
                 and self._url == other._url
                 and self._data == other._data
                 and self._loaded == other._loaded
                 and self._attribs == other._attribs
             )
         if isinstance(other, dict):
-            return self.as_dict() == other
+            return self._data == other
         return NotImplemented
 
     def __ne__(self, other: object) -> bool:
@@ -458,12 +457,7 @@ class LazyObject(dict):
             return NotImplemented
         return not result
 
-    def __hash__(self) -> int:
-        return hash((self.weblate, self._url))
-
-    def as_dict(self) -> dict[str, Any]:
-        """Return the object data using the lazy attribute mapping."""
-        return dict(self.items())
+    __hash__ = None
 
     def get_data(self):
         return copy(self._data)

--- a/wlc/__init__.py
+++ b/wlc/__init__.py
@@ -441,7 +441,7 @@ class LazyObject(dict):
     def __eq__(self, other: object) -> bool:
         if isinstance(other, LazyObject):
             return (
-                dict(self) == dict(other)
+                self.as_dict() == other.as_dict()
                 and self.weblate == other.weblate
                 and self._url == other._url
                 and self._data == other._data
@@ -449,8 +449,21 @@ class LazyObject(dict):
                 and self._attribs == other._attribs
             )
         if isinstance(other, dict):
-            return dict(self) == other
+            return self.as_dict() == other
         return NotImplemented
+
+    def __ne__(self, other: object) -> bool:
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return not result
+
+    def __hash__(self) -> int:
+        return hash((self.weblate, self._url))
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the object data using the lazy attribute mapping."""
+        return dict(self.items())
 
     def get_data(self):
         return copy(self._data)

--- a/wlc/test_wlc.py
+++ b/wlc/test_wlc.py
@@ -421,6 +421,82 @@ class ObjectTest(ObjectTestBaseClass, ABC):
         self.assertIsNone(obj.delete())
 
 
+class LazyObjectEqualityTest(APITest):
+    """Tests for equality and hashing on lazy objects."""
+
+    def test_equality_uses_additional_attributes(self) -> None:
+        """Objects with different deferred attributes should not compare equal."""
+        weblate = Weblate()
+        first = Project(
+            weblate,
+            "projects/hello/",
+            name="Hello",
+            slug="hello",
+            web="https://weblate.org/",
+            web_url="https://weblate.org/projects/hello/",
+            components_list_url="projects/hello/components/",
+        )
+        second = Project(
+            weblate,
+            "projects/hello/",
+            name="Hello",
+            slug="hello",
+            web="https://weblate.org/",
+            web_url="https://weblate.org/projects/hello/",
+            categories_url="projects/hello/categories/",
+        )
+
+        self.assertNotEqual(first, second)
+
+    def test_hash_matches_equality(self) -> None:
+        """Equal lazy objects should produce the same hash value."""
+        weblate = Weblate()
+        first = Project(
+            weblate,
+            "projects/hello/",
+            name="Hello",
+            slug="hello",
+            web="https://weblate.org/",
+            web_url="https://weblate.org/projects/hello/",
+            components_list_url="projects/hello/components/",
+        )
+        second = Project(
+            weblate,
+            "projects/hello/",
+            name="Hello",
+            slug="hello",
+            web="https://weblate.org/",
+            web_url="https://weblate.org/projects/hello/",
+            components_list_url="projects/hello/components/",
+        )
+
+        self.assertEqual(first, second)
+        self.assertEqual(hash(first), hash(second))
+        self.assertEqual(len({first, second}), 1)
+
+    def test_can_compare_to_dict(self) -> None:
+        """Lazy objects should still compare equal to matching dict values."""
+        obj = Project(
+            Weblate(),
+            "projects/hello/",
+            name="Hello",
+            slug="hello",
+            web="https://weblate.org/",
+            web_url="https://weblate.org/projects/hello/",
+        )
+
+        self.assertEqual(
+            obj,
+            {
+                "name": "Hello",
+                "slug": "hello",
+                "url": "projects/hello/",
+                "web": "https://weblate.org/",
+                "web_url": "https://weblate.org/projects/hello/",
+            },
+        )
+
+
 class ProjectTest(ObjectTest):
     """Project object tests."""
 

--- a/wlc/test_wlc.py
+++ b/wlc/test_wlc.py
@@ -10,6 +10,7 @@ import io
 import os
 from abc import ABC
 from typing import Any, ClassVar
+from unittest.mock import patch
 
 from requests.exceptions import RequestException
 from urllib3.util.retry import Retry
@@ -422,7 +423,7 @@ class ObjectTest(ObjectTestBaseClass, ABC):
 
 
 class LazyObjectEqualityTest(APITest):
-    """Tests for equality and hashing on lazy objects."""
+    """Tests for equality behavior on lazy objects."""
 
     def test_equality_uses_additional_attributes(self) -> None:
         """Objects with different deferred attributes should not compare equal."""
@@ -448,34 +449,41 @@ class LazyObjectEqualityTest(APITest):
 
         self.assertNotEqual(first, second)
 
-    def test_hash_matches_equality(self) -> None:
-        """Equal lazy objects should produce the same hash value."""
+    def test_equality_does_not_refresh_unloaded_objects(self) -> None:
+        """Comparing unloaded objects should not trigger a refresh."""
         weblate = Weblate()
-        first = Project(
-            weblate,
-            "projects/hello/",
-            name="Hello",
-            slug="hello",
-            web="https://weblate.org/",
-            web_url="https://weblate.org/projects/hello/",
-            components_list_url="projects/hello/components/",
-        )
-        second = Project(
-            weblate,
-            "projects/hello/",
-            name="Hello",
-            slug="hello",
-            web="https://weblate.org/",
-            web_url="https://weblate.org/projects/hello/",
-            components_list_url="projects/hello/components/",
-        )
+        first = Project(weblate, "projects/hello/")
+        second = Project(weblate, "projects/hello/")
+        with (
+            patch.object(
+                first, "refresh", side_effect=AssertionError("refresh should not run")
+            ) as first_refresh,
+            patch.object(
+                second, "refresh", side_effect=AssertionError("refresh should not run")
+            ) as second_refresh,
+        ):
+            self.assertEqual(first, second)
+            first_refresh.assert_not_called()
+            second_refresh.assert_not_called()
 
-        self.assertEqual(first, second)
-        self.assertEqual(hash(first), hash(second))
-        self.assertEqual(len({first, second}), 1)
+    def test_lazy_objects_are_not_hashable(self) -> None:
+        """Lazy objects should stay unhashable because equality is mutable."""
+        obj = Project(Weblate(), "projects/hello/")
 
-    def test_can_compare_to_dict(self) -> None:
-        """Lazy objects should still compare equal to matching dict values."""
+        with self.assertRaises(TypeError):
+            hash(obj)
+
+    def test_dict_comparison_does_not_refresh_unloaded_objects(self) -> None:
+        """Comparing unloaded objects to dicts should stay local."""
+        obj = Project(Weblate(), "projects/hello/")
+        with patch.object(
+            obj, "refresh", side_effect=AssertionError("refresh should not run")
+        ) as refresh:
+            self.assertEqual(obj, {"url": "projects/hello/"})
+            refresh.assert_not_called()
+
+    def test_dict_comparison_uses_lazy_data(self) -> None:
+        """Dict comparison should use lazy object data, not dict base storage."""
         obj = Project(
             Weblate(),
             "projects/hello/",
@@ -488,9 +496,9 @@ class LazyObjectEqualityTest(APITest):
         self.assertEqual(
             obj,
             {
+                "url": "projects/hello/",
                 "name": "Hello",
                 "slug": "hello",
-                "url": "projects/hello/",
                 "web": "https://weblate.org/",
                 "web_url": "https://weblate.org/projects/hello/",
             },


### PR DESCRIPTION
The best fix is to implement `__eq__` on `LazyObject` so equality includes both mapping content and the newly introduced contextual attributes (at minimum `weblate` and `_url`; including internal state fields keeps semantics consistent with current object state). This preserves existing functionality while making comparisons explicit and safe.

In `wlc/__init__.py`, inside `class LazyObject` (near existing dunder methods such as `__str__`), add a `__eq__(self, other)` method that:

- Returns `NotImplemented` for unrelated types.
- For another `LazyObject`, compares:
  - `dict(self)` vs `dict(other)` (the inherited mapping content),
  - `self.weblate == other.weblate`,
  - `self._url == other._url`,
  - and current internal state fields (`_data`, `_loaded`, `_attribs`) for full consistency.
- Optionally supports comparison to plain `dict` by delegating to `dict(self) == other`, preserving expected dict-like behavior.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._