### PR TITLE
fix: reject cross origin API requests

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -86,7 +86,7 @@ class CLITestBase(APITest, ABC):
         finally:
             sys.stdout = backup
             sys.stderr = backup_err
-        result = output.buffer.getvalue()  # ty:ignore[unresolved-attribute]
+        result = output.buffer.getvalue()
         if result:
             return result
         return output.getvalue()

--- a/tests/test_wlc.py
+++ b/tests/test_wlc.py
@@ -12,6 +12,7 @@ from abc import ABC
 from typing import Any, ClassVar
 from unittest.mock import patch
 
+import responses
 from requests.exceptions import RequestException
 from urllib3.util.retry import Retry
 
@@ -106,6 +107,150 @@ class WeblateErrorTest(APITest):
         self.assertEqual(obj.name, "Hello")
         with self.assertRaises(AttributeError):
             print(obj.invalid_attribute)
+
+
+class WeblateURLValidationTest(APITest):
+    """Tests request URL normalization for server-provided URLs."""
+
+    evil_domain = "http://evil.example.com/api"
+
+    def assert_origin_rejected(self, action, attacker_url, method=responses.GET):
+        """Assert the client rejects a cross-origin URL before any request is sent."""
+        attacker_requests = []
+
+        def trap(request):
+            attacker_requests.append(request)
+            return 200, {}, "{}"
+
+        responses.add_callback(
+            method,
+            attacker_url,
+            callback=trap,
+            content_type="application/json",
+        )
+
+        with self.assertRaisesRegex(
+            WeblateException, "outside the configured API origin"
+        ):
+            action()
+
+        self.assertFalse(attacker_requests)
+        self.assertFalse(
+            any(
+                call.request.url is None or call.request.url.startswith(attacker_url)
+                for call in responses.calls
+            )
+        )
+
+    def test_rejects_cross_origin_pagination_url(self) -> None:
+        """Pagination should not follow a hostile absolute next URL."""
+        attacker_url = f"{self.evil_domain}/projects/"
+        responses.add(
+            responses.GET,
+            "http://127.0.0.1:8000/api/hostile-projects/",
+            json={"next": attacker_url, "results": []},
+        )
+
+        self.assert_origin_rejected(
+            lambda: list(Weblate(key="KEY").list_projects("hostile-projects/")),
+            attacker_url,
+        )
+
+    def test_rejects_cross_origin_refresh_url(self) -> None:
+        """Lazy refresh should reject a hostile object URL from the API."""
+        attacker_url = f"{self.evil_domain}/projects/hostile/"
+        responses.add(
+            responses.GET,
+            "http://127.0.0.1:8000/api/projects/hostile/",
+            json={
+                "name": "Hostile",
+                "slug": "hostile",
+                "url": attacker_url,
+                "web": "https://example.com/projects/hostile/",
+                "web_url": "https://example.com/projects/hostile/",
+            },
+        )
+
+        self.assert_origin_rejected(
+            lambda: Weblate(key="KEY").get_project("hostile").refresh(),
+            attacker_url,
+        )
+
+    def test_rejects_cross_origin_file_download_url(self) -> None:
+        """Translation downloads should reject a hostile file_url."""
+        attacker_url = f"{self.evil_domain}/translations/hostile/weblate/cs/file/"
+        responses.add(
+            responses.GET,
+            "http://127.0.0.1:8000/api/translations/hostile/weblate/cs/",
+            json={
+                "url": "http://127.0.0.1:8000/api/translations/hostile/weblate/cs/",
+                "file_url": attacker_url,
+            },
+        )
+
+        self.assert_origin_rejected(
+            lambda: Weblate(key="KEY").get_translation("hostile/weblate/cs").download(),
+            attacker_url,
+        )
+
+    def test_rejects_cross_origin_file_upload_url(self) -> None:
+        """Translation uploads should reject a hostile file_url."""
+        attacker_url = f"{self.evil_domain}/translations/hostile/weblate/cs/file/"
+        responses.add(
+            responses.GET,
+            "http://127.0.0.1:8000/api/translations/hostile/weblate/cs/",
+            json={
+                "url": "http://127.0.0.1:8000/api/translations/hostile/weblate/cs/",
+                "file_url": attacker_url,
+            },
+        )
+
+        self.assert_origin_rejected(
+            lambda: (
+                Weblate(key="KEY")
+                .get_translation("hostile/weblate/cs")
+                .upload(io.StringIO("test upload data"))
+            ),
+            attacker_url,
+            method=responses.POST,
+        )
+
+    def test_rejects_cross_origin_repository_get_url(self) -> None:
+        """Repository reads should reject a hostile repository_url."""
+        attacker_url = f"{self.evil_domain}/translations/hostile/weblate/cs/repository/"
+        responses.add(
+            responses.GET,
+            "http://127.0.0.1:8000/api/translations/hostile/weblate/cs/",
+            json={
+                "url": "http://127.0.0.1:8000/api/translations/hostile/weblate/cs/",
+                "repository_url": attacker_url,
+            },
+        )
+
+        self.assert_origin_rejected(
+            lambda: (
+                Weblate(key="KEY").get_translation("hostile/weblate/cs").repository()
+            ),
+            attacker_url,
+        )
+
+    def test_rejects_cross_origin_repository_post_url(self) -> None:
+        """Repository mutations should reject a hostile repository_url."""
+        attacker_url = f"{self.evil_domain}/translations/hostile/weblate/cs/repository/"
+        responses.add(
+            responses.GET,
+            "http://127.0.0.1:8000/api/translations/hostile/weblate/cs/",
+            json={
+                "url": "http://127.0.0.1:8000/api/translations/hostile/weblate/cs/",
+                "repository_url": attacker_url,
+            },
+        )
+
+        self.assert_origin_rejected(
+            lambda: Weblate(key="KEY").get_translation("hostile/weblate/cs").commit(),
+            attacker_url,
+            method=responses.POST,
+        )
 
 
 class WeblateTest(APITest):

--- a/wlc/client.py
+++ b/wlc/client.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import logging
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import requests
 from requests import Response
@@ -83,6 +83,32 @@ class Weblate:
 
         if not self.url.endswith("/"):
             self.url += "/"
+        self.api_origin = self.get_origin(urlparse(self.url))
+
+    @staticmethod
+    def get_effective_port(url) -> int | None:
+        """Return explicit port or the default for the URL scheme."""
+        if url.port is not None:
+            return url.port
+        if url.scheme == "https":
+            return 443
+        if url.scheme == "http":
+            return 80
+        return None
+
+    @classmethod
+    def get_origin(cls, url) -> tuple[str, str | None, int | None]:
+        """Return normalized origin tuple for a parsed URL."""
+        return (url.scheme, url.hostname, cls.get_effective_port(url))
+
+    def normalize_request_url(self, path: str) -> str:
+        """Resolve a request path and reject cross-origin targets."""
+        url = urlparse(urljoin(self.url, path))
+        if self.get_origin(url) != self.api_origin:
+            raise WeblateException(
+                "Server returned a URL outside the configured API origin."
+            )
+        return url.geturl()
 
     @staticmethod
     def permission_error_message(error):
@@ -183,8 +209,11 @@ class Weblate:
         params: dict[str, str] | None = None,
     ) -> Response:
         """Construct request object."""
-        if not path.startswith("http"):
-            path = f"{self.url}{path}"
+        try:
+            path = self.normalize_request_url(path)
+        except WeblateException as error:
+            log_failure_debug(method, path, error)
+            raise
         headers = {"user-agent": USER_AGENT, "Accept": "application/json"}
         if self.key:
             headers["Authorization"] = f"Token {self.key}"


### PR DESCRIPTION
The server is not expected to use API URLs pointing to other server. This might be a breaking change for misconfigured servers which listen on different host than what is exposed in the API.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
