### PR TITLE
Harden retry defaults by removing TRACE from allowed methods

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,7 +94,7 @@ class WeblateConfigTestCase(TestCase):
         ) = config.get_request_options()
         self.assertEqual(
             allowed_methods,
-            ["HEAD", "TRACE", "DELETE", "OPTIONS", "PUT", "GET"],
+            ["HEAD", "DELETE", "OPTIONS", "PUT", "GET"],
         )
 
     def test_allowed_methods_strip_comma_separated_values(self) -> None:

--- a/wlc/client.py
+++ b/wlc/client.py
@@ -81,7 +81,6 @@ class Weblate:
                 "PATCH",
                 "DELETE",
                 "OPTIONS",
-                "TRACE",
             ]
             self.backoff_factor = backoff_factor
 

--- a/wlc/config.py
+++ b/wlc/config.py
@@ -45,9 +45,7 @@ class WeblateConfig(RawConfigParser):
         self.set(self.section, "retries", "0")
         self.set(self.section, "timeout", "300")
         self.set(self.section, "status_forcelist", None)
-        self.set(
-            self.section, "allowed_methods", "HEAD\nDELETE\nOPTIONS\nPUT\nGET"
-        )
+        self.set(self.section, "allowed_methods", "HEAD\nDELETE\nOPTIONS\nPUT\nGET")
         self.set(self.section, "backoff_factor", "0")
 
     @staticmethod

--- a/wlc/config.py
+++ b/wlc/config.py
@@ -46,7 +46,7 @@ class WeblateConfig(RawConfigParser):
         self.set(self.section, "timeout", "300")
         self.set(self.section, "status_forcelist", None)
         self.set(
-            self.section, "allowed_methods", "HEAD\nTRACE\nDELETE\nOPTIONS\nPUT\nGET"
+            self.section, "allowed_methods", "HEAD\nDELETE\nOPTIONS\nPUT\nGET"
         )
         self.set(self.section, "backoff_factor", "0")
 


### PR DESCRIPTION
### Motivation
- Reduce attack surface by removing the rarely-needed HTTP `TRACE` method from the default retry-eligible methods used by the HTTP client.
- Keep configuration defaults aligned with code defaults so users who rely on config get the same safer behavior.

### Description
- Removed `"TRACE"` from the default `allowed_methods` used when initializing `Weblate` in `wlc/client.py` so the adapter `Retry` will not include it by default.
- Updated the configuration default in `wlc/config.py` to omit `TRACE` from the `allowed_methods` default string.
- Adjusted the test expectation in `tests/test_config.py` to match the new default allowed methods.

### Testing
- Ran `python -m compileall -q wlc tests/test_config.py`, which succeeded and ensured code compiles.
- Ran `pytest -q tests/test_config.py tests/test_wlc.py`, which failed during test collection due to missing external test dependencies (`requests` and `responses`) in this environment, so full test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8b407a108329b24190b385d007ff)