### PR TITLE
Remove TRACE from default allowed HTTP methods

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,7 +94,7 @@ class WeblateConfigTestCase(TestCase):
         ) = config.get_request_options()
         self.assertEqual(
             allowed_methods,
-            ["HEAD", "TRACE", "DELETE", "OPTIONS", "PUT", "GET"],
+            ["HEAD", "DELETE", "OPTIONS", "PUT", "GET"],
         )
 
     def test_allowed_methods_strip_comma_separated_values(self) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -239,7 +239,7 @@ class TestSettings(CLITestBase):
         self.assertEqual(config.get("weblate", "timeout"), "300")
         self.assertEqual(
             config.get("weblate", "allowed_methods"),
-            "HEAD\nTRACE\nDELETE\nOPTIONS\nPUT\nGET",
+            "HEAD\nDELETE\nOPTIONS\nPUT\nGET",
         )
         self.assertEqual(config.get("weblate", "backoff_factor"), "0")
         self.assertIsNone(config.get("weblate", "status_forcelist"))
@@ -289,7 +289,7 @@ class TestSettings(CLITestBase):
         self.assertIsNone(status_forcelist)
         self.assertEqual(
             allowed_methods,
-            ["HEAD", "TRACE", "DELETE", "OPTIONS", "PUT", "GET"],
+            ["HEAD", "DELETE", "OPTIONS", "PUT", "GET"],
         )
         self.assertEqual(backoff_factor, 0.0)
         self.assertEqual(timeout, 300)

--- a/wlc/client.py
+++ b/wlc/client.py
@@ -81,7 +81,6 @@ class Weblate:
                 "PATCH",
                 "DELETE",
                 "OPTIONS",
-                "TRACE",
             ]
             self.backoff_factor = backoff_factor
 

--- a/wlc/config.py
+++ b/wlc/config.py
@@ -45,9 +45,7 @@ class WeblateConfig(RawConfigParser):
         self.set(self.section, "retries", "0")
         self.set(self.section, "timeout", "300")
         self.set(self.section, "status_forcelist", None)
-        self.set(
-            self.section, "allowed_methods", "HEAD\nDELETE\nOPTIONS\nPUT\nGET"
-        )
+        self.set(self.section, "allowed_methods", "HEAD\nDELETE\nOPTIONS\nPUT\nGET")
         self.set(self.section, "backoff_factor", "0")
 
     @staticmethod

--- a/wlc/config.py
+++ b/wlc/config.py
@@ -46,7 +46,7 @@ class WeblateConfig(RawConfigParser):
         self.set(self.section, "timeout", "300")
         self.set(self.section, "status_forcelist", None)
         self.set(
-            self.section, "allowed_methods", "HEAD\nTRACE\nDELETE\nOPTIONS\nPUT\nGET"
+            self.section, "allowed_methods", "HEAD\nDELETE\nOPTIONS\nPUT\nGET"
         )
         self.set(self.section, "backoff_factor", "0")
 


### PR DESCRIPTION
### Motivation
- The default retry/allowed HTTP methods should not include the `TRACE` method to avoid retrying or permitting a potentially unsafe/deprecated method by default.

### Description
- Removed `TRACE` from the default `allowed_methods` in `wlc/config.py` and the fallback list in `wlc/client.py`, and updated related test expectations in `tests/test_config.py` and `tests/test_main.py`.

### Testing
- Ran the updated unit tests for the affected expectations with `pytest` (including `tests/test_config.py::WeblateConfigTestCase::test_default_allowed_methods_splits_newlines` and `tests/test_main.py::TestSettings::test_default_config_values` and `tests/test_main.py::TestSettings::test_default_request_options`) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8b407a108329b24190b385d007ff)