### PR TITLE
fix: require explicit URL for unscoped API keys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+2.0.1
+-----
+
+* Released on 26th June 2026.
+* Require explicit URL pinning for unscoped API keys when the API URL comes
+  from automatically discovered project configuration: ``WLC_KEY`` requires
+  ``WLC_URL`` and ``--key`` requires ``--url``.
+
 2.0.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,16 @@ https://hosted.weblate.org/api/ = APIKEY
 ## Environment variables
 
 The API URL and key can also be configured using environment variables. This is
-especially useful for CI workflows where the repository provides the project
-configuration and `WLC_KEY` is injected as a secret:
+especially useful for CI workflows where `WLC_KEY` is injected as a secret:
 
 - `WLC_URL` — API URL
 - `WLC_KEY` — API key
+
+When the API URL comes from automatically discovered project configuration
+(`.weblate`, `.weblate.ini`, or `weblate.ini` in the current directory or a
+parent directory), unscoped secrets must pin the destination explicitly:
+`WLC_KEY` requires `WLC_URL`, and `--key` requires `--url`. URL-scoped keys in
+the `[keys]` section continue to work with project configuration.
 
 The configuration precedence (highest to lowest) is:
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -248,8 +248,8 @@ class WeblateConfigTestCase(TestCase):
             config.get("weblate", "url"), "https://parent.example.com/api/"
         )
 
-    def test_default_discovery_supports_repo_config_with_env_key(self) -> None:
-        """Project config can provide URL while WLC_KEY provides the secret."""
+    def test_project_config_with_env_key_requires_env_url(self) -> None:
+        """Project config URL can not be paired with unscoped WLC_KEY."""
         with TemporaryDirectory() as tmpdirname:
             root = Path(tmpdirname)
             nested = root / "repo"
@@ -264,12 +264,138 @@ class WeblateConfigTestCase(TestCase):
                 config = WeblateConfig()
                 with patch.object(WeblateConfig, "find_config", return_value=None):
                     config.load()
-                os.environ["WLC_KEY"] = "env-api-key"
+                with (
+                    patch.dict(os.environ, {"WLC_KEY": "env-api-key"}, clear=True),
+                    self.assertRaisesRegex(
+                        WLCConfigurationError,
+                        "Using WLC_KEY with project configuration requires WLC_URL",
+                    ),
+                ):
+                    config.get_url_key()
+            finally:
+                os.chdir(current)
+
+    def test_project_config_with_env_key_allows_env_url(self) -> None:
+        """WLC_KEY can be used when WLC_URL pins the destination."""
+        with TemporaryDirectory() as tmpdirname:
+            root = Path(tmpdirname)
+            nested = root / "repo"
+            nested.mkdir()
+            (nested / ".weblate").write_text(
+                "[weblate]\nurl = https://repo.example.com/api/\n",
+                encoding="utf-8",
+            )
+            current = os.getcwd()
+            try:
+                os.chdir(nested)
+                config = WeblateConfig()
+                with patch.object(WeblateConfig, "find_config", return_value=None):
+                    config.load()
+                with patch.dict(
+                    os.environ,
+                    {
+                        "WLC_KEY": "env-api-key",
+                        "WLC_URL": "https://env.example.com/api/",
+                    },
+                    clear=True,
+                ):
+                    url, key = config.get_url_key()
+            finally:
+                os.chdir(current)
+
+        self.assertEqual(url, "https://env.example.com/api/")
+        self.assertEqual(key, "env-api-key")
+
+    def test_project_config_with_cli_key_requires_cli_url(self) -> None:
+        """Project config URL can not be paired with unscoped --key."""
+        with TemporaryDirectory() as tmpdirname:
+            root = Path(tmpdirname)
+            nested = root / "repo"
+            nested.mkdir()
+            (nested / ".weblate").write_text(
+                "[weblate]\nurl = https://repo.example.com/api/\n",
+                encoding="utf-8",
+            )
+            current = os.getcwd()
+            try:
+                os.chdir(nested)
+                config = WeblateConfig()
+                with patch.object(WeblateConfig, "find_config", return_value=None):
+                    config.load()
+                config.cli_key = "cli-api-key"
+
+                with self.assertRaisesRegex(
+                    WLCConfigurationError,
+                    "Using --key with project configuration requires --url",
+                ):
+                    config.get_url_key()
+            finally:
+                os.chdir(current)
+
+    def test_project_config_with_cli_key_allows_cli_url(self) -> None:
+        """--key can be used when --url pins the destination."""
+        with TemporaryDirectory() as tmpdirname:
+            root = Path(tmpdirname)
+            nested = root / "repo"
+            nested.mkdir()
+            (nested / ".weblate").write_text(
+                "[weblate]\nurl = https://repo.example.com/api/\n",
+                encoding="utf-8",
+            )
+            current = os.getcwd()
+            try:
+                os.chdir(nested)
+                config = WeblateConfig()
+                with patch.object(WeblateConfig, "find_config", return_value=None):
+                    config.load()
+                config.cli_key = "cli-api-key"
+                config.cli_url = "https://cli.example.com/api/"
                 url, key = config.get_url_key()
             finally:
                 os.chdir(current)
-                if "WLC_KEY" in os.environ:
-                    del os.environ["WLC_KEY"]
+
+        self.assertEqual(url, "https://cli.example.com/api/")
+        self.assertEqual(key, "cli-api-key")
+
+    def test_project_config_allows_scoped_keys(self) -> None:
+        """Project config URL can use matching URL-scoped keys."""
+        with TemporaryDirectory() as tmpdirname:
+            root = Path(tmpdirname)
+            nested = root / "repo"
+            nested.mkdir()
+            (nested / ".weblate").write_text(
+                "[weblate]\nurl = https://repo.example.com/api/\n"
+                "\n"
+                "[keys]\nhttps://repo.example.com/api/ = scoped-api-key\n",
+                encoding="utf-8",
+            )
+            current = os.getcwd()
+            try:
+                os.chdir(nested)
+                config = WeblateConfig()
+                with patch.object(WeblateConfig, "find_config", return_value=None):
+                    config.load()
+                url, key = config.get_url_key()
+            finally:
+                os.chdir(current)
 
         self.assertEqual(url, "https://repo.example.com/api/")
+        self.assertEqual(key, "scoped-api-key")
+
+    def test_explicit_config_with_env_key_remains_supported(self) -> None:
+        """Explicit config URL can still be paired with WLC_KEY."""
+        with TemporaryDirectory() as tmpdirname:
+            root = Path(tmpdirname)
+            explicit = root / "explicit.ini"
+            explicit.write_text(
+                "[weblate]\nurl = https://explicit.example.com/api/\n",
+                encoding="utf-8",
+            )
+            config = WeblateConfig()
+            config.load(explicit)
+
+            with patch.dict(os.environ, {"WLC_KEY": "env-api-key"}, clear=True):
+                url, key = config.get_url_key()
+
+        self.assertEqual(url, "https://explicit.example.com/api/")
         self.assertEqual(key, "env-api-key")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,7 @@ from abc import ABC
 from io import BytesIO, StringIO, TextIOWrapper
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import wlc
 from wlc.config import WeblateConfig
@@ -221,6 +222,117 @@ class TestSettings(CLITestBase):
             self.assertIn("Hello", output)
         finally:
             del os.environ["WLC_URL"]
+
+    def test_project_config_with_env_key_reports_error(self) -> None:
+        """WLC_KEY can not use a URL from discovered project config."""
+        current = os.path.abspath(".")
+        with TemporaryDirectory() as tmpdirname:
+            repo = os.path.join(tmpdirname, "repo")
+            os.makedirs(repo)
+            with open(os.path.join(repo, ".weblate"), "w", encoding="utf-8") as handle:
+                handle.write("[weblate]\nurl = http://denied.example.com/api/\n")
+
+            try:
+                os.chdir(repo)
+                with (
+                    patch.object(WeblateConfig, "find_config", return_value=None),
+                    patch.dict(os.environ, {"WLC_KEY": "KEY"}, clear=True),
+                ):
+                    output = self.execute(["show", "acl"], settings=False, expected=1)
+            finally:
+                os.chdir(current)
+
+        self.assertIn(
+            "Error: Using WLC_KEY with project configuration requires WLC_URL.",
+            output,
+        )
+
+    def test_project_config_with_env_key_allows_env_url(self) -> None:
+        """WLC_KEY can use WLC_URL even when project config is present."""
+        current = os.path.abspath(".")
+        with TemporaryDirectory() as tmpdirname:
+            repo = os.path.join(tmpdirname, "repo")
+            os.makedirs(repo)
+            with open(os.path.join(repo, ".weblate"), "w", encoding="utf-8") as handle:
+                handle.write("[weblate]\nurl = http://denied.example.com/api/\n")
+
+            try:
+                os.chdir(repo)
+                with (
+                    patch.object(WeblateConfig, "find_config", return_value=None),
+                    patch.dict(
+                        os.environ,
+                        {
+                            "WLC_KEY": "KEY",
+                            "WLC_URL": "http://127.0.0.1:8000/api/",
+                        },
+                        clear=True,
+                    ),
+                ):
+                    output = self.execute(["show", "acl"], settings=False)
+            finally:
+                os.chdir(current)
+
+        self.assertIn("ACL", output)
+
+    def test_project_config_with_cli_key_reports_error(self) -> None:
+        """--key can not use a URL from discovered project config."""
+        current = os.path.abspath(".")
+        with TemporaryDirectory() as tmpdirname:
+            repo = os.path.join(tmpdirname, "repo")
+            os.makedirs(repo)
+            with open(os.path.join(repo, ".weblate"), "w", encoding="utf-8") as handle:
+                handle.write("[weblate]\nurl = http://denied.example.com/api/\n")
+
+            try:
+                os.chdir(repo)
+                with (
+                    patch.object(WeblateConfig, "find_config", return_value=None),
+                    patch.dict(os.environ, {}, clear=True),
+                ):
+                    output = self.execute(
+                        ["--key", "KEY", "show", "acl"],
+                        settings=False,
+                        expected=1,
+                    )
+            finally:
+                os.chdir(current)
+
+        self.assertIn(
+            "Error: Using --key with project configuration requires --url.",
+            output,
+        )
+
+    def test_project_config_with_cli_key_allows_cli_url(self) -> None:
+        """--key can use --url even when project config is present."""
+        current = os.path.abspath(".")
+        with TemporaryDirectory() as tmpdirname:
+            repo = os.path.join(tmpdirname, "repo")
+            os.makedirs(repo)
+            with open(os.path.join(repo, ".weblate"), "w", encoding="utf-8") as handle:
+                handle.write("[weblate]\nurl = http://denied.example.com/api/\n")
+
+            try:
+                os.chdir(repo)
+                with (
+                    patch.object(WeblateConfig, "find_config", return_value=None),
+                    patch.dict(os.environ, {}, clear=True),
+                ):
+                    output = self.execute(
+                        [
+                            "--key",
+                            "KEY",
+                            "--url",
+                            "http://127.0.0.1:8000/api/",
+                            "show",
+                            "acl",
+                        ],
+                        settings=False,
+                    )
+            finally:
+                os.chdir(current)
+
+        self.assertIn("ACL", output)
 
     def test_config_cwd(self) -> None:
         """Test loading settings from current dir."""

--- a/wlc/config.py
+++ b/wlc/config.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import os.path
 from configparser import NoOptionError, RawConfigParser
-from typing import TYPE_CHECKING, TypeAlias, cast
+from typing import TYPE_CHECKING, Literal, TypeAlias, cast
 
 from xdg.BaseDirectory import load_first_config
 
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 __all__ = ["NoOptionError", "WLCConfigurationError", "WeblateConfig"]
 
 RequestOptions: TypeAlias = tuple[int, list[int] | None, list[str], float, int]
+URLSource: TypeAlias = Literal["default", "cli", "env", "explicit", "user", "project"]
+KeySource: TypeAlias = Literal["none", "cli", "env", "keys"]
 
 
 class WLCConfigurationError(Exception):
@@ -35,6 +37,7 @@ class WeblateConfig(RawConfigParser):
         self.section: str = section
         self.cli_key: str | None = None
         self.cli_url: str | None = None
+        self._config_url_source: URLSource = "default"
         self.set_defaults()
 
     def set_defaults(self) -> None:
@@ -79,37 +82,79 @@ class WeblateConfig(RawConfigParser):
 
         return None
 
+    def _read_config(self, path: Path | str, url_source: URLSource) -> list[str]:
+        """Read configuration and remember whether it supplied the API URL."""
+        parser = RawConfigParser(delimiters=("=",))
+        loaded = parser.read(path)
+        if not loaded:
+            return loaded
+
+        self.read(path)
+        if parser.has_option(self.section, "url"):
+            self._config_url_source = url_source
+
+        return loaded
+
     def load(self, path: Path | str | None = None) -> None:
         """Load configuration from an explicit path or discovered locations."""
         if path:
-            loaded = self.read(path)
+            loaded = self._read_config(path, "explicit")
             if not loaded:
                 raise WLCConfigurationError(
                     f"Could not read configuration file: {os.path.abspath(path)}"
                 )
         else:
             if config := self.find_config():
-                self.read(config)
+                self._read_config(config, "user")
             if config := self.find_project_config():
-                self.read(config)
+                self._read_config(config, "project")
 
         if self.has_option(self.section, "key"):
             raise WLCConfigurationError(
                 "Using 'key' in settings is insecure, use [keys] section instead."
             )
 
+    def _get_url_key_sources(self) -> tuple[str, URLSource, str, KeySource]:
+        """Get API URL, key, and their sources."""
+        if self.cli_url:
+            url = self.cli_url
+            url_source: URLSource = "cli"
+        elif env_url := os.environ.get("WLC_URL", ""):
+            url = env_url
+            url_source = "env"
+        else:
+            url = cast("str", self.get(self.section, "url"))
+            url_source = self._config_url_source
+
+        if self.cli_key:
+            key = self.cli_key
+            key_source: KeySource = "cli"
+        elif env_key := os.environ.get("WLC_KEY", ""):
+            key = env_key
+            key_source = "env"
+        else:
+            key = cast("str", self.get("keys", url, fallback=""))
+            key_source = "keys" if key else "none"
+
+        if url_source == "project":
+            if key_source == "cli":
+                raise WLCConfigurationError(
+                    "Using --key with project configuration requires --url."
+                )
+            if key_source == "env":
+                raise WLCConfigurationError(
+                    "Using WLC_KEY with project configuration requires WLC_URL."
+                )
+
+        return url, url_source, key, key_source
+
+    def validate_url_key(self) -> None:
+        """Validate URL and key source combination."""
+        self._get_url_key_sources()
+
     def get_url_key(self) -> tuple[str, str]:
         """Get API URL and key."""
-        url = (
-            self.cli_url
-            or os.environ.get("WLC_URL", "")
-            or cast("str", self.get(self.section, "url"))
-        )
-        key = (
-            self.cli_key
-            or os.environ.get("WLC_KEY", "")
-            or cast("str", self.get("keys", url, fallback=""))
-        )
+        url, _url_source, key, _key_source = self._get_url_key_sources()
         return url, key
 
     def get_request_options(self) -> RequestOptions:

--- a/wlc/const.py
+++ b/wlc/const.py
@@ -4,7 +4,7 @@
 
 """Package constants."""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 URL = "https://weblate.org/"
 DEVEL_URL = "https://github.com/WeblateOrg/wlc"

--- a/wlc/main.py
+++ b/wlc/main.py
@@ -937,6 +937,8 @@ def parse_settings(args: Namespace, settings: SettingsSource | None) -> WeblateC
     if args.url:
         config.cli_url = args.url
 
+    config.validate_url_key()
+
     return config
 
 


### PR DESCRIPTION
Reject WLC_KEY or --key when the API URL comes only from automatically discovered project configuration. Allow the combinations when WLC_URL or --url pins the destination, and keep URL-scoped keys supported.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
