### PR TITLE
fix: avoid global warning handling changes

### DIFF
--- a/tests/test_wlc.py
+++ b/tests/test_wlc.py
@@ -8,12 +8,15 @@ from __future__ import annotations
 
 import io
 import os
+import warnings
 from abc import ABC
 from typing import ClassVar
 from unittest.mock import patch
 from urllib.parse import urlencode
 
 import responses
+from requests import Response
+from urllib3.exceptions import InsecureRequestWarning
 from urllib3.util.retry import Retry
 
 from wlc import (
@@ -247,6 +250,33 @@ class WeblateTest(APITest):
             Weblate.should_verify_ssl("https://localhost.example.com/api/"), True
         )
         self.assertEqual(Weblate.should_verify_ssl("http://example.com/api/"), True)
+
+    def test_insecure_warning_is_not_suppressed(self) -> None:
+        response = Response()
+        response.status_code = 200
+        weblate = Weblate(url="https://localhost/api/")
+
+        def request(*_args: object, **_kwargs: object) -> Response:
+            warnings.warn("insecure", InsecureRequestWarning, stacklevel=2)
+            warnings.warn("unrelated", UserWarning, stacklevel=2)
+            return response
+
+        with (
+            patch.object(weblate.session, "request", side_effect=request),
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            warnings.simplefilter("always")
+            weblate.invoke_request("GET", weblate.url)
+            warnings.warn("insecure afterward", InsecureRequestWarning, stacklevel=1)
+
+        self.assertEqual(
+            [(warning.category, str(warning.message)) for warning in caught],
+            [
+                (InsecureRequestWarning, "insecure"),
+                (UserWarning, "unrelated"),
+                (InsecureRequestWarning, "insecure afterward"),
+            ],
+        )
 
     def test_paginated_listing_uses_params_only_for_first_request(self) -> None:
         """The API-provided next URL already includes query parameters."""

--- a/wlc/client.py
+++ b/wlc/client.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import json
-import logging
 from collections.abc import Collection, Iterator, Mapping
 from ipaddress import ip_address
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
@@ -300,9 +299,6 @@ class Weblate:
             headers["Authorization"] = f"Token {self.key}"
         verify_ssl = self.should_verify_ssl(path)
 
-        # Disable insecure warnings for localhost
-        if not verify_ssl:
-            logging.captureWarnings(True)
         json_data: RequestPayload | None
         if files:
             # multipart/form upload


### PR DESCRIPTION
Stop changing process-wide warning handling when the library connects to localhost without TLS verification. Let urllib3 emit InsecureRequestWarning normally so concurrent requests cannot race while mutating shared warning state.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
