### PR TITLE
fix: avoid following download symlinks

### DIFF
--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,260 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Download command security tests."""
+
+from __future__ import annotations
+
+import errno
+import os
+import stat
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from .test_main import CLITestBase
+
+
+class TestDownloadSecurity(CLITestBase):
+    """Download destination security tests."""
+
+    def create_symlink(self, target: str | Path, link: Path) -> None:
+        """Create a symlink or skip on Windows without symlink privileges."""
+        try:
+            link.symlink_to(target)
+        except OSError:
+            if os.name == "nt":
+                self.skipTest("Symlink creation is not permitted")
+            raise
+
+    def test_component_rejects_symlink(self) -> None:
+        with TemporaryDirectory() as tmpdirname:
+            root = Path(tmpdirname)
+            output_directory = root / "repository"
+            output_directory.mkdir()
+            victim = root / "victim"
+            victim.write_bytes(b"original")
+            destination = output_directory / "hello-weblate.zip"
+            self.create_symlink("../victim", destination)
+
+            output = self.execute(
+                ["download", "hello/weblate", "--output", str(output_directory)],
+                expected=1,
+            )
+
+            self.assertIn("Refusing to write downloaded file through symlink", output)
+            self.assertTrue(destination.is_symlink())
+            self.assertEqual(victim.read_bytes(), b"original")
+
+    def test_translation_rejects_symlink(self) -> None:
+        with TemporaryDirectory() as tmpdirname:
+            root = Path(tmpdirname)
+            victim = root / "victim"
+            victim.write_bytes(b"original")
+            destination = root / "translation.po"
+            self.create_symlink("victim", destination)
+
+            output = self.execute(
+                ["download", "hello/weblate/cs", "--output", str(destination)],
+                expected=1,
+            )
+
+            self.assertIn("Refusing to write downloaded file through symlink", output)
+            self.assertTrue(destination.is_symlink())
+            self.assertEqual(victim.read_bytes(), b"original")
+
+    def test_rejects_non_regular_destination(self) -> None:
+        with TemporaryDirectory() as tmpdirname:
+            output_directory = Path(tmpdirname)
+            destination = output_directory / "hello-weblate.zip"
+            destination.mkdir()
+
+            output = self.execute(
+                ["download", "hello/weblate", "--output", str(output_directory)],
+                expected=1,
+            )
+
+            self.assertIn(
+                "Refusing to write downloaded file to non-regular path", output
+            )
+            self.assertTrue(destination.is_dir())
+
+    def test_does_not_follow_racing_symlink(self) -> None:
+        with TemporaryDirectory() as tmpdirname:
+            root = Path(tmpdirname)
+            output_directory = root / "repository"
+            output_directory.mkdir()
+            victim = root / "victim"
+            victim.write_bytes(b"original")
+            destination = output_directory / "hello-weblate.zip"
+            self.create_symlink("../victim", destination)
+
+            with patch("wlc.main._download_destination_stat", return_value=None):
+                self.execute(
+                    [
+                        "download",
+                        "hello/weblate",
+                        "--output",
+                        str(output_directory),
+                    ]
+                )
+
+            self.assertFalse(destination.is_symlink())
+            self.assertNotEqual(destination.read_bytes(), b"original")
+            self.assertEqual(victim.read_bytes(), b"original")
+
+    def test_supports_long_destination_basename(self) -> None:
+        if os.name == "nt":
+            self.skipTest("Test basenames can exceed the legacy Windows path limit")
+
+        with TemporaryDirectory() as tmpdirname:
+            root = Path(tmpdirname)
+            for basename in ("a" * 250, "é" * 120):
+                with self.subTest(basename=basename[:10]):
+                    destination = root / basename
+                    self.execute(
+                        [
+                            "download",
+                            "hello/weblate/cs",
+                            "--output",
+                            str(destination),
+                        ]
+                    )
+                    self.assertTrue(destination.is_file())
+
+    def test_replaces_regular_file(self) -> None:
+        with TemporaryDirectory() as tmpdirname:
+            output_directory = Path(tmpdirname)
+            destination = output_directory / "hello-weblate.zip"
+            destination.write_bytes(b"old content")
+            destination.chmod(0o640)
+            original_stat = destination.stat()
+
+            self.execute(
+                ["download", "hello/weblate", "--output", str(output_directory)]
+            )
+
+            self.assertNotEqual(destination.read_bytes(), b"old content")
+            self.assertEqual(destination.stat().st_ino, original_stat.st_ino)
+            if os.name != "nt":
+                self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o640)
+
+    def test_updates_existing_file_without_temporary_inode(self) -> None:
+        with TemporaryDirectory() as tmpdirname:
+            destination = Path(tmpdirname) / "translation.po"
+            destination.write_bytes(b"old content")
+
+            with patch(
+                "wlc.main._open_download_temporary",
+                side_effect=OSError(errno.ENOSPC, "No space left on device"),
+            ) as open_temporary:
+                self.execute(
+                    [
+                        "download",
+                        "hello/weblate/cs",
+                        "--output",
+                        str(destination),
+                    ]
+                )
+
+            open_temporary.assert_not_called()
+            self.assertNotEqual(destination.read_bytes(), b"old content")
+
+    def test_replaces_hard_link_without_modifying_target(self) -> None:
+        with TemporaryDirectory() as tmpdirname:
+            root = Path(tmpdirname)
+            output_directory = root / "repository"
+            output_directory.mkdir()
+            victim = root / "victim"
+            victim.write_bytes(b"original")
+            destination = output_directory / "hello-weblate.zip"
+            destination.hardlink_to(victim)
+
+            self.execute(
+                ["download", "hello/weblate", "--output", str(output_directory)]
+            )
+
+            self.assertNotEqual(destination.read_bytes(), b"original")
+            self.assertEqual(victim.read_bytes(), b"original")
+            self.assertFalse(destination.samefile(victim))
+
+    def test_updates_writable_file_in_protected_directory(self) -> None:
+        if os.name == "nt" or not hasattr(os, "geteuid") or os.geteuid() == 0:
+            self.skipTest("POSIX permissions require an unprivileged user")
+
+        with TemporaryDirectory() as tmpdirname:
+            output_directory = Path(tmpdirname) / "protected"
+            output_directory.mkdir()
+            destination = output_directory / "translation.po"
+            destination.write_bytes(b"old content")
+            destination.chmod(0o600)
+            output_directory.chmod(0o500)
+            try:
+                self.execute(
+                    [
+                        "download",
+                        "hello/weblate/cs",
+                        "--output",
+                        str(destination),
+                    ]
+                )
+            finally:
+                output_directory.chmod(0o700)
+
+            self.assertNotEqual(destination.read_bytes(), b"old content")
+
+    def test_rejects_replaced_destination(self) -> None:
+        with TemporaryDirectory() as tmpdirname:
+            root = Path(tmpdirname)
+            destination = root / "translation.po"
+            destination.write_bytes(b"original")
+            replacement = root / "replacement"
+            replacement.write_bytes(b"replacement")
+            original_destination = root / "original-destination"
+            original_open = os.open
+            swapped = False
+
+            def replace_before_open(path, flags, mode=0o777, *, dir_fd=None):
+                nonlocal swapped
+                if Path(path).name == destination.name and not swapped:
+                    swapped = True
+                    destination.rename(original_destination)
+                    replacement.rename(destination)
+                return original_open(path, flags, mode, dir_fd=dir_fd)
+
+            with patch("wlc.main.os.open", side_effect=replace_before_open):
+                output = self.execute(
+                    [
+                        "download",
+                        "hello/weblate/cs",
+                        "--output",
+                        str(destination),
+                    ],
+                    expected=1,
+                )
+
+            self.assertIn("destination changed", output)
+            self.assertEqual(destination.read_bytes(), b"replacement")
+            self.assertEqual(original_destination.read_bytes(), b"original")
+
+    def test_failure_cleans_temporary_file(self) -> None:
+        with TemporaryDirectory() as tmpdirname:
+            output_directory = Path(tmpdirname)
+            with (
+                patch(
+                    "wlc.main._replace_download_file",
+                    side_effect=OSError("replace failed"),
+                ),
+                self.assertRaisesRegex(OSError, "replace failed"),
+            ):
+                self.execute(
+                    [
+                        "download",
+                        "hello/weblate",
+                        "--output",
+                        str(output_directory),
+                    ]
+                )
+
+            self.assertEqual(list(output_directory.iterdir()), [])

--- a/wlc/main.py
+++ b/wlc/main.py
@@ -9,11 +9,16 @@
 from __future__ import annotations
 
 import csv
+import errno
 import html
 import json
+import os
+import secrets
+import stat
 import sys
 from argparse import ArgumentParser, Namespace
 from collections.abc import Iterable, Mapping
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar, cast
 
@@ -111,6 +116,140 @@ class CommandError(Exception):
         if detail is not None:
             message = f"{message}\n{detail}"
         super().__init__(message)
+
+
+def _is_link(file_stat: os.stat_result) -> bool:
+    """Detect symbolic links and Windows reparse points."""
+    file_attributes = getattr(file_stat, "st_file_attributes", 0)
+    reparse_point = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    return stat.S_ISLNK(file_stat.st_mode) or bool(file_attributes & reparse_point)
+
+
+def _download_destination_stat(path: Path) -> os.stat_result | None:
+    """Stat a download destination without following it."""
+    try:
+        return path.lstat()
+    except FileNotFoundError:
+        return None
+
+
+def _open_download_temporary(path: Path) -> tuple[int, str]:
+    """Create a short, exclusive temporary download file."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
+    for _attempt in range(10):
+        temporary_name = f".wlc-{secrets.token_hex(4)}"
+        try:
+            descriptor = os.open(path.parent / temporary_name, flags, 0o666)
+        except FileExistsError:
+            continue
+        return descriptor, temporary_name
+    raise CommandError(f"Could not create temporary download file for: {path}")
+
+
+def _unlink_download_temporary(path: Path, temporary_name: str) -> None:
+    """Remove a temporary download file if it still exists."""
+    with suppress(FileNotFoundError):
+        (path.parent / temporary_name).unlink()
+
+
+def _replace_download_file(path: Path, temporary_name: str) -> None:
+    """Atomically replace a download destination."""
+    os.replace(path.parent / temporary_name, path)
+
+
+def _write_existing_download_file(
+    path: Path,
+    content: bytes,
+    destination_stat: os.stat_result,
+) -> None:
+    """Safely update an existing file while preserving its inode metadata."""
+    if destination_stat.st_nlink != 1:
+        raise CommandError(
+            f"Refusing to update multiply-linked downloaded file: {path}"
+        )
+
+    flags = (
+        os.O_WRONLY
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    try:
+        opened_descriptor = os.open(path, flags)
+    except OSError as error:
+        if error.errno == errno.ELOOP:
+            raise CommandError(
+                f"Refusing to write downloaded file through symlink: {path}"
+            ) from error
+        raise
+
+    descriptor = opened_descriptor
+    descriptor_open = True
+    try:
+        opened_stat = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened_stat.st_mode)
+            or opened_stat.st_nlink != 1
+            or (opened_stat.st_dev, opened_stat.st_ino)
+            != (destination_stat.st_dev, destination_stat.st_ino)
+        ):
+            raise CommandError(
+                f"Refusing to write downloaded file after destination changed: {path}"
+            )
+        os.ftruncate(descriptor, 0)
+        handle = os.fdopen(descriptor, "wb")
+        descriptor_open = False
+        with handle:
+            handle.write(content)
+    finally:
+        if descriptor_open:
+            os.close(descriptor)
+
+
+def _write_download_file(
+    path: Path, content: bytes, *, create_directory: bool = False
+) -> None:
+    """Write a download without following the destination entry."""
+    if create_directory:
+        path.parent.mkdir(exist_ok=True, parents=True)
+
+    destination_stat = _download_destination_stat(path)
+    destination_mode: int | None = None
+    if destination_stat is not None:
+        if _is_link(destination_stat):
+            raise CommandError(
+                f"Refusing to write downloaded file through symlink: {path}"
+            )
+        if not stat.S_ISREG(destination_stat.st_mode):
+            raise CommandError(
+                f"Refusing to write downloaded file to non-regular path: {path}"
+            )
+        destination_mode = stat.S_IMODE(destination_stat.st_mode)
+        if destination_stat.st_nlink == 1:
+            _write_existing_download_file(path, content, destination_stat)
+            return
+
+    opened_descriptor, temporary_name = _open_download_temporary(path)
+    descriptor = opened_descriptor
+    descriptor_open = True
+    temporary_exists = True
+    try:
+        if destination_mode is not None and hasattr(os, "fchmod"):
+            with suppress(NotImplementedError):
+                os.fchmod(descriptor, destination_mode)
+        handle = os.fdopen(descriptor, "wb")
+        descriptor_open = False
+        with handle:
+            handle.write(content)
+        _replace_download_file(path, temporary_name)
+        temporary_exists = False
+    finally:
+        try:
+            if descriptor_open:
+                os.close(descriptor)
+        finally:
+            if temporary_exists:
+                _unlink_download_temporary(path, temporary_name)
 
 
 def print_stderr(message: str) -> None:
@@ -752,8 +891,7 @@ class Download(ObjectCommand[CommandObject]):
         file_path = directory / (
             f"{sanitize_slug(component.project.slug)}-{sanitize_slug(component.slug)}.zip"
         )
-        directory.mkdir(exist_ok=True, parents=True)
-        file_path.write_bytes(content)
+        _write_download_file(file_path, content, create_directory=True)
 
     def download_components(self, iterable: Iterable[Component]) -> None:
         for component in iterable:
@@ -773,7 +911,7 @@ class Download(ObjectCommand[CommandObject]):
         if isinstance(obj, Translation):
             content = obj.download(self.args.convert)
             if self.args.output and self.args.output != "-":
-                Path(self.args.output).write_bytes(content)
+                _write_download_file(Path(self.args.output), content)
             else:
                 if stream_isatty(self.stdout):
                     raise CommandError(


### PR DESCRIPTION
Downloaded output names are predictable, so an untrusted checkout could preplant a link and redirect writes outside the output directory. Reject unsafe targets and atomically replace files to close the check/write race.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
