### PR TITLE
fix: disable automatic netrc authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ especially useful for CI workflows where `WLC_KEY` is injected as a secret:
 - `WLC_ALLOW_INSECURE_HTTP` — set to `1`, `true`, `yes`, or `on` to allow
   API keys over non-local HTTP URLs
 
+wlc does not load HTTP authentication from the user's `.netrc` or the file
+named by `NETRC`; configure credentials using the sources described here.
+Other Requests environment integration, including proxy and CA bundle
+variables, remains enabled.
+
 When the API URL comes from automatically discovered project configuration
 (`.weblate`, `.weblate.ini`, or `weblate.ini` in the current directory or a
 parent directory), unscoped secrets must pin the destination explicitly:

--- a/tests/test_wlc.py
+++ b/tests/test_wlc.py
@@ -10,12 +10,14 @@ import io
 import os
 import warnings
 from abc import ABC
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import ClassVar
 from unittest.mock import patch
 from urllib.parse import urlencode
 
 import responses
-from requests import Response
+from requests import Request, Response
 from urllib3.exceptions import InsecureRequestWarning
 from urllib3.util.retry import Retry
 
@@ -81,6 +83,76 @@ class WeblateTest(APITest):
             Weblate().get_object("acl")
         obj = Weblate(key="KEY").get_object("acl")
         self.assertEqual(obj.name, "ACL")
+
+    def assert_netrc_authentication_is_ignored(self) -> None:
+        """Assert netrc credentials are not added or used over an API token."""
+        for key, expected in (("", None), ("KEY", "Token KEY")):
+            with self.subTest(key=key):
+                Weblate(key=key).get_object("hello")
+
+                self.assertEqual(
+                    responses.calls[-1].request.headers.get("Authorization"),
+                    expected,
+                )
+
+    def test_netrc_environment_authentication_is_ignored(self) -> None:
+        """Credentials from the NETRC environment file should be ignored."""
+        with TemporaryDirectory() as tmpdirname:
+            netrc_path = Path(tmpdirname) / "credentials"
+            netrc_path.write_text(
+                "machine 127.0.0.1 login NETRC password SECRET\n",  # kingfisher:ignore
+                encoding="utf-8",
+            )
+            with patch.dict(os.environ, {"NETRC": str(netrc_path)}, clear=True):
+                self.assert_netrc_authentication_is_ignored()
+
+    def test_user_netrc_authentication_is_ignored(self) -> None:
+        """Credentials from the user's default netrc file should be ignored."""
+        with TemporaryDirectory() as tmpdirname:
+            netrc_path = Path(tmpdirname) / ".netrc"
+            netrc_path.write_text(
+                "machine 127.0.0.1 login NETRC password SECRET\n",  # kingfisher:ignore
+                encoding="utf-8",
+            )
+            netrc_path.chmod(0o600)
+            with (
+                patch.dict(os.environ, {}, clear=True),
+                patch(
+                    "requests.utils.os.path.expanduser", return_value=str(netrc_path)
+                ),
+            ):
+                self.assert_netrc_authentication_is_ignored()
+
+    def test_url_authentication_is_preserved(self) -> None:
+        """Disabling netrc should not disable URL-provided credentials."""
+        weblate = Weblate(url="https://user:password@example.com/api/")
+
+        request = weblate.session.prepare_request(Request("GET", weblate.url))
+
+        self.assertEqual(
+            request.headers.get("Authorization"),
+            "Basic dXNlcjpwYXNzd29yZA==",
+        )
+
+    def test_request_environment_settings_are_preserved(self) -> None:
+        """Proxy and CA bundle environment settings should remain enabled."""
+        with TemporaryDirectory() as tmpdirname:
+            ca_bundle = Path(tmpdirname) / "ca-bundle.pem"
+            ca_bundle.touch()
+            with patch.dict(
+                os.environ,
+                {
+                    "HTTPS_PROXY": "http://proxy.example.com:8080",
+                    "REQUESTS_CA_BUNDLE": str(ca_bundle),
+                },
+                clear=True,
+            ):
+                settings = Weblate().session.merge_environment_settings(
+                    "https://example.com/api/", {}, False, True, None
+                )
+
+        self.assertEqual(settings["proxies"]["https"], "http://proxy.example.com:8080")
+        self.assertEqual(settings["verify"], str(ca_bundle))
 
     def test_ensure_loaded(self) -> None:
         """Test lazy loading of attributes."""

--- a/wlc/client.py
+++ b/wlc/client.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
 from urllib.parse import urljoin
 
 import requests
+import requests.auth
+import requests.utils
 from requests import Response
 from requests.adapters import HTTPAdapter
 from urllib3.exceptions import LocationParseError
@@ -38,6 +40,19 @@ JSONDict: TypeAlias = dict[str, Any]
 RequestPayload: TypeAlias = Mapping[str, Any]
 WeblateObject: TypeAlias = Project | Component | Translation | Unit
 LazyObjectT = TypeVar("LazyObjectT", bound=LazyObject)
+
+
+# pylint: disable-next=too-few-public-methods
+class _NoNetrcAuth(requests.auth.AuthBase):
+    """Prevent netrc lookup while preserving URL-provided authentication."""
+
+    def __call__(self, r: requests.PreparedRequest) -> requests.PreparedRequest:
+        if r.url is None:
+            return r
+        username, password = requests.utils.get_auth_from_url(r.url)
+        if username or password:
+            return requests.auth.HTTPBasicAuth(username, password)(r)
+        return r
 
 
 class Weblate:
@@ -76,6 +91,7 @@ class Weblate:
     ) -> None:
         """Create the object, storing key, API URL, and request options."""
         self.session = requests.Session()
+        self.session.auth = _NoNetrcAuth()
         self.retry_total: int
         self.status_forcelist: Collection[int] | None
         self.allowed_methods: Collection[str]


### PR DESCRIPTION
Requests can derive Basic credentials from repository-selected hostnames and overwrite wlc's explicit Authorization header. Keep netrc outside the credential trust boundary while preserving proxy and CA environment settings.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
