### PR TITLE
fix: escape structured CSV cells

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -361,6 +361,17 @@ class TestSettings(CLITestBase):
             sys.argv = backup
 
 
+# pylint: disable-next=too-few-public-methods
+class RawControlValue:
+    """Value whose representation contains raw terminal controls."""
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __repr__(self) -> str:
+        return self.value
+
+
 class TestOutput(CLITestBase):
     """Test output formatting."""
 
@@ -507,14 +518,14 @@ class TestOutput(CLITestBase):
 
     def test_csv_output_escapes_controls_in_structured_values(self) -> None:
         """CSV output should escape controls after converting structured values."""
-        aliases = ["escape\x1b[31m", "nul\x00byte", "c1\x85byte"]
+        aliases = [RawControlValue("escape\x1b[31m nul\x00byte c1\x85byte")]
         values = (
-            {"aliases": aliases},
-            [AttributeDict({"aliases": aliases})],
+            ("detail", {"aliases": aliases}),
+            ("tabular", [AttributeDict({"aliases": aliases})]),
         )
 
-        for value in values:
-            with self.subTest(value=value):
+        for shape, value in values:
+            with self.subTest(shape=shape):
                 output = TTYStringIO()
                 cmd = self.create_command(output, "csv")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -505,6 +505,29 @@ class TestOutput(CLITestBase):
         self.assertIn(r"hello\x1b[31m\r\nworld", rendered)
         self.assertNotIn("\x1b", rendered)
 
+    def test_csv_output_escapes_controls_in_structured_values(self) -> None:
+        """CSV output should escape controls after converting structured values."""
+        aliases = ["escape\x1b[31m", "nul\x00byte", "c1\x85byte"]
+        values = (
+            {"aliases": aliases},
+            [AttributeDict({"aliases": aliases})],
+        )
+
+        for value in values:
+            with self.subTest(value=value):
+                output = TTYStringIO()
+                cmd = self.create_command(output, "csv")
+
+                cmd.print(value)
+
+                rendered = output.getvalue()
+                self.assertIn(r"escape\x1b[31m", rendered)
+                self.assertIn(r"nul\x00byte", rendered)
+                self.assertIn(r"c1\x85byte", rendered)
+                self.assertNotIn("\x1b", rendered)
+                self.assertNotIn("\x00", rendered)
+                self.assertNotIn("\x85", rendered)
+
     def test_csv_output_allows_missing_optional_fields(self) -> None:
         """CSV output should leave blank cells for missing optional fields."""
         output = StringIO()

--- a/wlc/main.py
+++ b/wlc/main.py
@@ -317,11 +317,9 @@ class Command:
             return to_value()
         return value
 
-    def format_csv_value(self, value: object) -> object:
+    def format_csv_value(self, value: object) -> str:
         """Format value for CSV output and harden dangerous spreadsheet cells."""
-        formatted = self.format_value(value)
-        if not isinstance(formatted, str):
-            return formatted
+        formatted = str(self.format_value(value))
 
         stripped = formatted.lstrip(CSV_DANGEROUS_LEADING)
         if stripped and stripped[0] in CSV_FORMULA_PREFIXES:


### PR DESCRIPTION
Stringify CSV values before terminal formatting so controls nested in structured API fields cannot bypass TTY escaping through csv.writer.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
