### PR TITLE
fix: reject credentials embedded in URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ especially useful for CI workflows where `WLC_KEY` is injected as a secret:
 
 wlc does not load HTTP authentication from the user's `.netrc` or the file
 named by `NETRC`; configure credentials using the sources described here.
+Credentials embedded in API URLs are rejected; use an API key instead.
 Other Requests environment integration, including proxy and CA bundle
 variables, remains enabled.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -379,6 +379,36 @@ class WeblateConfigTestCase(TestCase):
         config.cli_url = "https://repo.example.com/api/"
         self.assertFalse(config.get_allow_insecure_ssl())
 
+    def test_project_config_cannot_supply_url_credentials(self) -> None:
+        """A discovered project URL can not enable implicit authentication."""
+        with TemporaryDirectory() as tmpdirname:
+            root = Path(tmpdirname)
+            user_config = root / "global.ini"
+            user_config.write_text(
+                "[insecure_http]\nhttp://repo.example.com:80 = yes\n",
+                encoding="utf-8",
+            )
+            nested = root / "repo"
+            nested.mkdir()
+            (nested / ".weblate").write_text(
+                "[weblate]\nurl = http://user:password@repo.example.com/api/\n",
+                encoding="utf-8",
+            )
+            current = os.getcwd()
+            try:
+                os.chdir(nested)
+                config = WeblateConfig()
+                with patch.object(
+                    WeblateConfig, "find_config", return_value=str(user_config)
+                ):
+                    config.load()
+            finally:
+                os.chdir(current)
+
+        self.assertTrue(config.get_allow_insecure_http())
+        with self.assertRaisesRegex(wlc.WeblateException, "embedded in URLs"):
+            wlc.Weblate(config=config)
+
     def test_project_url_requires_transient_insecure_option_url_pairing(self) -> None:
         """Unscoped insecure overrides can not target a project-selected URL."""
         with TemporaryDirectory() as tmpdirname:

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -58,6 +58,23 @@ class WeblateURLValidationTest(APITest):
 
         self.assertEqual(projects, [])
 
+    def test_rejects_url_credentials(self) -> None:
+        """URL userinfo should not provide an implicit authentication channel."""
+        test_cases = (
+            ("https://user:password@example.com/api/", False),
+            ("http://user:password@127.0.0.1:8000/api/", False),
+            ("http://user:password@example.com/api/", True),
+        )
+
+        for url, allow_insecure_http in test_cases:
+            with (
+                self.subTest(url=url),
+                self.assertRaisesRegex(WeblateException, "embedded in URLs"),
+            ):
+                Weblate(url=url, allow_insecure_http=allow_insecure_http)
+
+        self.assertFalse(responses.calls)
+
     def assert_origin_rejected(self, action, attacker_url, method=responses.GET):
         """Assert the client rejects a cross-origin URL before any request is sent."""
         attacker_requests = []
@@ -113,6 +130,22 @@ class WeblateURLValidationTest(APITest):
             WeblateException, "outside the configured API origin"
         ):
             list(Weblate(key="KEY").list_projects("hostile-projects/"))
+
+        self.assertEqual(len(responses.calls), 1)
+
+    def test_rejects_url_credentials_in_pagination_url(self) -> None:
+        """Server-provided URLs can not introduce implicit Basic authentication."""
+        responses.add(
+            responses.GET,
+            "http://127.0.0.1:8000/api/hostile-projects/",
+            json={
+                "next": "http://user:password@127.0.0.1:8000/api/projects/",
+                "results": [],
+            },
+        )
+
+        with self.assertRaisesRegex(WeblateException, "embedded in URLs"):
+            list(Weblate().list_projects("hostile-projects/"))
 
         self.assertEqual(len(responses.calls), 1)
 

--- a/tests/test_wlc.py
+++ b/tests/test_wlc.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 from urllib.parse import urlencode
 
 import responses
-from requests import Request, Response
+from requests import Response
 from urllib3.exceptions import InsecureRequestWarning
 from urllib3.util.retry import Retry
 
@@ -122,17 +122,6 @@ class WeblateTest(APITest):
                 ),
             ):
                 self.assert_netrc_authentication_is_ignored()
-
-    def test_url_authentication_is_preserved(self) -> None:
-        """Disabling netrc should not disable URL-provided credentials."""
-        weblate = Weblate(url="https://user:password@example.com/api/")
-
-        request = weblate.session.prepare_request(Request("GET", weblate.url))
-
-        self.assertEqual(
-            request.headers.get("Authorization"),
-            "Basic dXNlcjpwYXNzd29yZA==",
-        )
 
     def test_request_environment_settings_are_preserved(self) -> None:
         """Proxy and CA bundle environment settings should remain enabled."""

--- a/wlc/client.py
+++ b/wlc/client.py
@@ -14,7 +14,6 @@ from urllib.parse import urljoin
 
 import requests
 import requests.auth
-import requests.utils
 from requests import Response
 from requests.adapters import HTTPAdapter
 from urllib3.exceptions import LocationParseError
@@ -44,14 +43,9 @@ LazyObjectT = TypeVar("LazyObjectT", bound=LazyObject)
 
 # pylint: disable-next=too-few-public-methods
 class _NoNetrcAuth(requests.auth.AuthBase):
-    """Prevent netrc lookup while preserving URL-provided authentication."""
+    """Prevent automatic authentication from ambient credential sources."""
 
     def __call__(self, r: requests.PreparedRequest) -> requests.PreparedRequest:
-        if r.url is None:
-            return r
-        username, password = requests.utils.get_auth_from_url(r.url)
-        if username or password:
-            return requests.auth.HTTPBasicAuth(username, password)(r)
         return r
 
 
@@ -74,7 +68,8 @@ class Weblate:
     When an API key is configured, non-local ``http://`` URLs are rejected by
     default. Use HTTPS, loopback HTTP for local development, or set
     ``allow_insecure_http`` only for legacy deployments where HTTPS is not
-    available.
+    available. Credentials embedded in API URLs are not supported; configure
+    an API key instead.
     """
 
     def __init__(
@@ -159,11 +154,17 @@ class Weblate:
 
     @staticmethod
     def parse_request_url(url: str) -> Url:
-        """Parse a URL using the parser used by the HTTP transport."""
+        """Parse and validate a URL using the HTTP transport's parser."""
         try:
-            return parse_url(url)
+            parsed_url = parse_url(url)
         except LocationParseError as error:
             raise WeblateException("Invalid URL.") from error
+        if parsed_url.auth is not None:
+            raise WeblateException(
+                "Credentials embedded in URLs are not supported. "
+                "Configure an API key instead."
+            )
+        return parsed_url
 
     def validate_authenticated_transport(self) -> None:
         """Prevent sending API tokens over non-local cleartext HTTP."""


### PR DESCRIPTION
URL userinfo created an implicit Basic authentication path that bypassed API-key source and insecure-transport checks. Restrict authentication to configured API keys.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
