### PR TITLE
fix: redact credentials from request failure logs

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -6,9 +6,10 @@
 
 from __future__ import annotations
 
-from requests.exceptions import RequestException
+from requests.exceptions import InvalidHeader, RequestException
 
 from wlc import (
+    API_URL,
     Weblate,
     WeblateException,
 )
@@ -70,6 +71,22 @@ class WeblateErrorTest(APITest):
         """Test handling of OS/request-level errors when listing projects."""
         with self.assertRaises(RequestException):
             Weblate().get_object("io")
+
+    def test_debug_failure_redacts_invalid_authorization(self) -> None:
+        """Invalid authorization headers should not leak into debug logs."""
+        key = "debug-secret\ncontinuation"
+        with (
+            self.assertLogs("wlc", level="DEBUG") as captured,
+            self.assertRaises(InvalidHeader),
+        ):
+            Weblate(key=key).invoke_request("GET", API_URL)
+
+        output = "\n".join(captured.output)
+        self.assertIn("HTTP failure", output)
+        self.assertIn("<redacted>", output)
+        self.assertIn("Invalid leading whitespace", output)
+        self.assertNotIn("debug-secret", output)
+        self.assertNotIn("continuation", output)
 
     def test_bug(self) -> None:
         """Test handling of a FileNotFoundError when listing projects."""

--- a/wlc/client.py
+++ b/wlc/client.py
@@ -358,7 +358,7 @@ class Weblate:
             if 300 <= response.status_code < 400:
                 raise requests.HTTPError("Server redirected", response=response)
         except requests.exceptions.RequestException as error:
-            log_failure_debug(method, path, error)
+            log_failure_debug(method, path, error, headers=headers)
             self.process_error(error)
             raise
         return response

--- a/wlc/http_debug.py
+++ b/wlc/http_debug.py
@@ -72,12 +72,32 @@ def log_response_debug(response: Response) -> None:
     )
 
 
-def log_failure_debug(method: str, path: str, error: Exception) -> None:
+def redact_sensitive_values(message: str, headers: Mapping[str, str]) -> str:
+    """Redact sensitive header values embedded in a message."""
+    for key, value in headers.items():
+        if key.lower() not in SENSITIVE_HEADERS or not value:
+            continue
+        # Requests can include either the value itself or its repr in exceptions.
+        message = message.replace(repr(value), "<redacted>")
+        message = message.replace(value, "<redacted>")
+    return message
+
+
+def log_failure_debug(
+    method: str,
+    path: str,
+    error: Exception,
+    *,
+    headers: Mapping[str, str] | None = None,
+) -> None:
     """Emit a debug log for failed HTTP requests."""
     if not log.isEnabledFor(logging.DEBUG):
         return
 
-    log.debug("HTTP failure %s %s -> %s", method.upper(), path, error)
+    error_message = str(error)
+    if headers is not None:
+        error_message = redact_sensitive_values(error_message, headers)
+    log.debug("HTTP failure %s %s -> %s", method.upper(), path, error_message)
 
 
 def enable_debug_logging() -> tuple[logging.Handler, int, bool]:


### PR DESCRIPTION
Requests can embed invalid Authorization header values in exception messages. Scrub sensitive header values before emitting HTTP failure debug logs.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
