### PR TITLE
Fix component download when slug contains repository

### DIFF
--- a/tests/test_wlc.py
+++ b/tests/test_wlc.py
@@ -702,37 +702,40 @@ class ComponentTest(ObjectTest):
         resp = obj.patch(priority=80)
         self.assertIn("--patched--", resp.decode())
 
+
 def test_download_preserves_repository_in_slug(self) -> None:
-        """Download URL must rewrite only the trailing /repository/ segment.
+    """
+    Download URL must rewrite only the trailing /repository/ segment.
 
-        A global substring replacement would corrupt legal component slugs
-        containing "repository" (e.g. docs_repository) and request the wrong
-        component's file endpoint.
-        """
-        weblate = Weblate()
-        slug = "docs_repository"
-        base = "http://127.0.0.1:8000/api"
-        obj = Component(
-            weblate,
-            url=f"components/hello/{slug}/",
-            repository_url=f"{base}/components/hello/{slug}/repository/",
-        )
-        file_url = f"{base}/components/hello/{slug}/file/"
-        corrupted_url = f"{base}/components/hello/docs_file/file/"
-        responses.add(
-            responses.GET,
-            file_url,
-            body=b"correct-archive",
-            content_type="application/zip",
-        )
-        responses.add(responses.GET, corrupted_url, status=500)
+    A global substring replacement would corrupt legal component slugs
+    containing "repository" (e.g. docs_repository) and request the wrong
+    component's file endpoint.
+    """
+    weblate = Weblate()
+    slug = "docs_repository"
+    base = "http://127.0.0.1:8000/api"
+    obj = Component(
+        weblate,
+        url=f"components/hello/{slug}/",
+        repository_url=f"{base}/components/hello/{slug}/repository/",
+    )
+    file_url = f"{base}/components/hello/{slug}/file/"
+    corrupted_url = f"{base}/components/hello/docs_file/file/"
+    responses.add(
+        responses.GET,
+        file_url,
+        body=b"correct-archive",
+        content_type="application/zip",
+    )
+    responses.add(responses.GET, corrupted_url, status=500)
 
-        content = obj.download()
+    content = obj.download()
 
-        self.assertEqual(content, b"correct-archive")
-        requested = [call.request.url for call in responses.mock.calls]
-        self.assertIn(file_url, requested)
-        self.assertNotIn(corrupted_url, requested)
+    self.assertEqual(content, b"correct-archive")
+    requested = [call.request.url for call in responses.mock.calls]
+    self.assertIn(file_url, requested)
+    self.assertNotIn(corrupted_url, requested)
+
 
 class ComponentCompatibilityTest(ObjectTest):
     """Tests a component with lack of all optional fields in a response."""

--- a/tests/test_wlc.py
+++ b/tests/test_wlc.py
@@ -702,6 +702,37 @@ class ComponentTest(ObjectTest):
         resp = obj.patch(priority=80)
         self.assertIn("--patched--", resp.decode())
 
+def test_download_preserves_repository_in_slug(self) -> None:
+        """Download URL must rewrite only the trailing /repository/ segment.
+
+        A global substring replacement would corrupt legal component slugs
+        containing "repository" (e.g. docs_repository) and request the wrong
+        component's file endpoint.
+        """
+        weblate = Weblate()
+        slug = "docs_repository"
+        base = "http://127.0.0.1:8000/api"
+        obj = Component(
+            weblate,
+            url=f"components/hello/{slug}/",
+            repository_url=f"{base}/components/hello/{slug}/repository/",
+        )
+        file_url = f"{base}/components/hello/{slug}/file/"
+        corrupted_url = f"{base}/components/hello/docs_file/file/"
+        responses.add(
+            responses.GET,
+            file_url,
+            body=b"correct-archive",
+            content_type="application/zip",
+        )
+        responses.add(responses.GET, corrupted_url, status=500)
+
+        content = obj.download()
+
+        self.assertEqual(content, b"correct-archive")
+        requested = [call.request.url for call in responses.mock.calls]
+        self.assertIn(file_url, requested)
+        self.assertNotIn(corrupted_url, requested)
 
 class ComponentCompatibilityTest(ObjectTest):
     """Tests a component with lack of all optional fields in a response."""

--- a/tests/test_wlc.py
+++ b/tests/test_wlc.py
@@ -702,40 +702,37 @@ class ComponentTest(ObjectTest):
         resp = obj.patch(priority=80)
         self.assertIn("--patched--", resp.decode())
 
-
 def test_download_preserves_repository_in_slug(self) -> None:
-    """
-    Download URL must rewrite only the trailing /repository/ segment.
+        """Download URL must rewrite only the trailing /repository/ segment.
 
-    A global substring replacement would corrupt legal component slugs
-    containing "repository" (e.g. docs_repository) and request the wrong
-    component's file endpoint.
-    """
-    weblate = Weblate()
-    slug = "docs_repository"
-    base = "http://127.0.0.1:8000/api"
-    obj = Component(
-        weblate,
-        url=f"components/hello/{slug}/",
-        repository_url=f"{base}/components/hello/{slug}/repository/",
-    )
-    file_url = f"{base}/components/hello/{slug}/file/"
-    corrupted_url = f"{base}/components/hello/docs_file/file/"
-    responses.add(
-        responses.GET,
-        file_url,
-        body=b"correct-archive",
-        content_type="application/zip",
-    )
-    responses.add(responses.GET, corrupted_url, status=500)
+        A global substring replacement would corrupt legal component slugs
+        containing "repository" (e.g. docs_repository) and request the wrong
+        component's file endpoint.
+        """
+        weblate = Weblate()
+        slug = "docs_repository"
+        base = "http://127.0.0.1:8000/api"
+        obj = Component(
+            weblate,
+            url=f"components/hello/{slug}/",
+            repository_url=f"{base}/components/hello/{slug}/repository/",
+        )
+        file_url = f"{base}/components/hello/{slug}/file/"
+        corrupted_url = f"{base}/components/hello/docs_file/file/"
+        responses.add(
+            responses.GET,
+            file_url,
+            body=b"correct-archive",
+            content_type="application/zip",
+        )
+        responses.add(responses.GET, corrupted_url, status=500)
 
-    content = obj.download()
+        content = obj.download()
 
-    self.assertEqual(content, b"correct-archive")
-    requested = [call.request.url for call in responses.mock.calls]
-    self.assertIn(file_url, requested)
-    self.assertNotIn(corrupted_url, requested)
-
+        self.assertEqual(content, b"correct-archive")
+        requested = [call.request.url for call in responses.mock.calls]
+        self.assertIn(file_url, requested)
+        self.assertNotIn(corrupted_url, requested)
 
 class ComponentCompatibilityTest(ObjectTest):
     """Tests a component with lack of all optional fields in a response."""

--- a/tests/test_wlc.py
+++ b/tests/test_wlc.py
@@ -702,40 +702,38 @@ class ComponentTest(ObjectTest):
         resp = obj.patch(priority=80)
         self.assertIn("--patched--", resp.decode())
 
-
-def test_download_preserves_repository_in_slug(self) -> None:
-    """
-    Download URL must rewrite only the trailing /repository/ segment.
-
-    A global substring replacement would corrupt legal component slugs
-    containing "repository" (e.g. docs_repository) and request the wrong
-    component's file endpoint.
-    """
-    weblate = Weblate()
-    slug = "docs_repository"
-    base = "http://127.0.0.1:8000/api"
-    obj = Component(
-        weblate,
-        url=f"components/hello/{slug}/",
-        repository_url=f"{base}/components/hello/{slug}/repository/",
-    )
-    file_url = f"{base}/components/hello/{slug}/file/"
-    corrupted_url = f"{base}/components/hello/docs_file/file/"
-    responses.add(
-        responses.GET,
-        file_url,
-        body=b"correct-archive",
-        content_type="application/zip",
-    )
-    responses.add(responses.GET, corrupted_url, status=500)
-
-    content = obj.download()
-
-    self.assertEqual(content, b"correct-archive")
-    requested = [call.request.url for call in responses.mock.calls]
-    self.assertIn(file_url, requested)
-    self.assertNotIn(corrupted_url, requested)
-
+    def test_download_preserves_repository_in_slug(self) -> None:
+        """
+        Download URL must rewrite only the trailing /repository/ segment.
+    
+        A global substring replacement would corrupt legal component slugs
+        containing "repository" (e.g. docs_repository) and request the wrong
+        component's file endpoint.
+        """
+        weblate = Weblate()
+        slug = "docs_repository"
+        base = "http://127.0.0.1:8000/api"
+        obj = Component(
+            weblate,
+            url=f"components/hello/{slug}/",
+            repository_url=f"{base}/components/hello/{slug}/repository/",
+        )
+        file_url = f"{base}/components/hello/{slug}/file/"
+        corrupted_url = f"{base}/components/hello/docs_file/file/"
+        responses.add(
+            responses.GET,
+            file_url,
+            body=b"correct-archive",
+            content_type="application/zip",
+        )
+        responses.add(responses.GET, corrupted_url, status=500)
+    
+        content = obj.download()
+    
+        self.assertEqual(content, b"correct-archive")
+        requested = [call.request.url for call in responses.mock.calls]
+        self.assertIn(file_url, requested)
+        self.assertNotIn(corrupted_url, requested)
 
 class ComponentCompatibilityTest(ObjectTest):
     """Tests a component with lack of all optional fields in a response."""

--- a/tests/test_wlc.py
+++ b/tests/test_wlc.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 """Test the module."""
+# pylint: disable=too-many-lines
 
 from __future__ import annotations
 

--- a/tests/test_wlc.py
+++ b/tests/test_wlc.py
@@ -705,7 +705,7 @@ class ComponentTest(ObjectTest):
     def test_download_preserves_repository_in_slug(self) -> None:
         """
         Download URL must rewrite only the trailing /repository/ segment.
-    
+
         A global substring replacement would corrupt legal component slugs
         containing "repository" (e.g. docs_repository) and request the wrong
         component's file endpoint.
@@ -727,13 +727,14 @@ class ComponentTest(ObjectTest):
             content_type="application/zip",
         )
         responses.add(responses.GET, corrupted_url, status=500)
-    
+
         content = obj.download()
-    
+
         self.assertEqual(content, b"correct-archive")
         requested = [call.request.url for call in responses.mock.calls]
         self.assertIn(file_url, requested)
         self.assertNotIn(corrupted_url, requested)
+
 
 class ComponentCompatibilityTest(ObjectTest):
     """Tests a component with lack of all optional fields in a response."""

--- a/wlc/models.py
+++ b/wlc/models.py
@@ -364,7 +364,11 @@ class Component(RepoObjectMixin, LazyObject):
     def download(self, convert: str | None = None) -> bytes:
         """Download translation file from server."""
         self.ensure_loaded("repository_url")
-        url = self._get_repo_url().replace("repository", "file")
+        # Rewrite only the trailing /repository/ endpoint segment. A global
+        # substring replacement would also corrupt component slugs that
+        # legitimately contain "repository" (e.g. docs_repository), fetching
+        # an unrelated component's archive or a 404.
+        url = self._get_repo_url().removesuffix("/repository/") + "/file/"
         if convert is not None:
             url = f"{url}?{urlencode({'format': convert})}"
         return self.weblate.raw_request("get", url)


### PR DESCRIPTION
Fixes #1697

Component.download() rewrote the whole repository_url with
str.replace("repository", "file"), corrupting legal component slugs such as
docs_repository → requests went to the unrelated docs_file component
(wrong archive saved, exit 0) or 404'd.

Now only the trailing /repository/ segment is rewritten
(removesuffix), leaving slugs intact.

Verification:
- New regression test test_download_preserves_repository_in_slug
  FAILS on main (request hits the wrong component), PASSES with this change.
- Full suite with fix: 277 passed, 19 subtests passed.